### PR TITLE
Deprecate S3 bucket ACL

### DIFF
--- a/groups/storage/s3.tf
+++ b/groups/storage/s3.tf
@@ -3,11 +3,6 @@ resource "aws_s3_bucket" "data" {
   tags   = local.common_tags
 }
 
-resource "aws_s3_bucket_acl" "data" {
-  bucket = aws_s3_bucket.data.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_versioning" "data" {
   bucket = aws_s3_bucket.data.id
   versioning_configuration {


### PR DESCRIPTION
This change removes the unnecessary S3 bucket ACL in favour of Object Ownership configuration which is already present in the codebase.