### PR TITLE
add new s3 ssl policy

### DIFF
--- a/groups/storage/data.tf
+++ b/groups/storage/data.tf
@@ -56,4 +56,29 @@ data "aws_iam_policy_document" "bucket" {
       values   = ["aws:kms"]
     }
   }
+
+  statement {
+    sid = "allow_ssl_requests_only"
+    effect = "Deny"
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "s3:*"
+    ]
+
+    resources = [
+      "${aws_s3_bucket.data.arn}",
+      "${aws_s3_bucket.data.arn}/*"
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
 }


### PR DESCRIPTION
Adding a required more secure SSL object access only policy to the S3 buckets 